### PR TITLE
use composite action in shared repo

### DIFF
--- a/.github/workflows/pr-build-test-with-composite-action.yml
+++ b/.github/workflows/pr-build-test-with-composite-action.yml
@@ -16,7 +16,7 @@ jobs:
           echo "Hello from before composite action"
 
       - name: Build and Publish .NET Core App
-        uses: devopselvis/my-github-actions-presentation/.github/actions/build-and-publish@main
+        uses: devopselvis/build-test-net-core-app-custom-action@main
         with:
           dotnet-version: "8.0.x"
           project-path: "${{ github.workspace }}/src/my-web-app/my-web-app.csproj"


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file to update the action used for building and publishing the .NET Core application. The most important change is: